### PR TITLE
Updated template_redirect priority

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -4,6 +4,7 @@
 
 	<!-- What to scan -->
 	<file>.</file>
+	<exclude-pattern>/svn/</exclude-pattern>
 	<exclude-pattern>/vendor/</exclude-pattern>
 	<exclude-pattern>/node_modules/</exclude-pattern>
 

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,9 @@ make-zip:
 svn:
 	cp -v -r plugin-assets/* svn/assets/
 	cp -v -r *.php *.txt imageengine assets templates svn/trunk
+
+phpcs:
+	../phpcs/bin/phpcs --standard=WordPress .
+
+phpcs-fix:
+	../phpcs/bin/phpcbf --standard=WordPress .

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,14 @@
 .PHONY: % dist-clean dist make-zip svn
 
-FILE := image-cdn-0.0.0.zip
-
 dist-clean:
 	rm -rf dist/image_cdn
 
 dist: dist-clean make-zip
 
 make-zip:
-	rm dist/${FILE} || echo -n ""
 	mkdir -p dist/image_cdn
 	cp -v -r *.php *.txt imageengine assets templates dist/image_cdn/
-	cd dist && zip -9 -r ${FILE} image_cdn
+	cd dist && zip -9 -r image-cdn-$$(grep -o 'Version: .*' ../image-cdn.php | cut -d ' ' -f2).zip image_cdn
 	rm -rf dist/image_cdn
 
 svn:

--- a/image-cdn.php
+++ b/image-cdn.php
@@ -6,7 +6,7 @@
  * Author: imageengine
  * Author URI: https://imageengine.io/
  * License: GPLv2 or later
- * Version: 1.0.3
+ * Version: 1.0.4
  */
 
 require_once __DIR__ . '/imageengine/class-settings.php';

--- a/imageengine/class-imagecdn.php
+++ b/imageengine/class-imagecdn.php
@@ -28,14 +28,14 @@ class ImageCDN {
 		// Only enable the hooks if the configuration is valid and the plugin is enabled.
 		if ( self::should_rewrite() ) {
 			// Rewriter hook.
-			add_action( 'template_redirect', array( self::class, 'handle_rewrite_hook' ) );
+			add_action( 'template_redirect', array( self::class, 'handle_rewrite_hook', 0 ) );
 
 			// Rewrite rendered content in REST API.
 			add_filter( 'the_content', array( self::class, 'rewrite_the_content' ), 100 );
 
 			// Resource hints.
-			//add_action( 'wp_head', array( self::class, 'add_head_tags' ), 0 );
-      add_action( 'send_headers', array( self::class, 'add_headers' ), 0 );
+			// add_action( 'wp_head', array( self::class, 'add_head_tags' ), 0 );
+			add_action( 'send_headers', array( self::class, 'add_headers' ), 0 );
 		}
 
 		// Hooks.
@@ -52,15 +52,15 @@ class ImageCDN {
 	 */
 	public static function add_headers() {
 		// Add client hints.
-        header( 'Accept-CH: viewport-width, width, device-memory, dpr, rtt, downlink, ect' );
+		header( 'Accept-CH: viewport-width, width, device-memory, dpr, rtt, downlink, ect' );
 
 		// Add resource hints and feature policy.
 		$options = self::get_options();
 		$host    = wp_parse_url( $options['url'], PHP_URL_HOST );
 		if ( ! empty( $host ) ) {
-    		$protocol = (is_ssl()) ? "https://" : "http://";
-        header( 'Link: <'.$protocol.$host.'>; rel=preconnect' );
-        header( 'Feature-Policy: ch-viewport-width '.$protocol.$host.'; ch-width '.$protocol.$host.'; ch device-memory '.$protocol.$host.'; ch-dpr '.$protocol.$host.'; ch-rtt '.$protocol.$host.'; ch-downlink '.$protocol.$host.'; ch-ect '.$protocol.$host.';' );
+			$protocol = ( is_ssl() ) ? 'https://' : 'http://';
+			header( 'Link: <' . $protocol . $host . '>; rel=preconnect' );
+			header( 'Feature-Policy: ch-viewport-width ' . $protocol . $host . '; ch-width ' . $protocol . $host . '; ch device-memory ' . $protocol . $host . '; ch-dpr ' . $protocol . $host . '; ch-rtt ' . $protocol . $host . '; ch-downlink ' . $protocol . $host . '; ch-ect ' . $protocol . $host . ';' );
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -119,6 +119,9 @@ Upgrades can be performed in the normal WordPress way, nothing else will need to
 
 == Changelog ==
 
+= 1.0.4 =
+* Updated plugin priority
+
 = 1.0.3 =
 * Support for Client Hints and Feature Policy
 

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -20,7 +20,7 @@
 		</p>
 		<p><?php esc_html_e( 'To obtain an ImageEngine CDN hostname' ); ?>:</p>
 		<ol>
-			<li><a target="_blank" href="https://imageengine.io/signup/?website=<?php echo get_site_url();?>&?utm_source=WP-plugin-settigns&utm_medium=page&utm_term=wp-imageengine&utm_campaign=wp-imageengine">Sign up for an ImageEngine account</a></li>
+			<li><a target="_blank" href="https://imageengine.io/signup/?website=<?php echo esc_attr( rawurlencode( get_site_url() ) ); ?>&?utm_source=WP-plugin-settigns&utm_medium=page&utm_term=wp-imageengine&utm_campaign=wp-imageengine">Sign up for an ImageEngine account</a></li>
 			<li>
 			<?php
 				printf(
@@ -76,10 +76,11 @@
 							<?php
 							printf(
 								// translators: 1: Link to account control panel
-								esc_html__('Enter your ImageEngine (or other Image CDN) URL. For ImageEngine, this can be found in your %1$s. In most cases, this will be a scheme and a hostname, like', 'image-cdn' ),
+								esc_html__( 'Enter your ImageEngine (or other Image CDN) URL. For ImageEngine, this can be found in your %1$s. In most cases, this will be a scheme and a hostname, like', 'image-cdn' ),
 								'<a href="https://my.scientiamobile.com/" target="_blank">account control panel</a>'
 							);
-							?> <code>https://my-site.cdn.imgeng.in</code>.
+							?>
+							<code>https://my-site.cdn.imgeng.in</code>.
 						</p>
 					</fieldset>
 				</td>


### PR DESCRIPTION
- Set `template_redirect` action priority to `0` instead of the default `10`.
- Used `rawurlencode` and `esc_attr` to ensure the URL is properly escaped.
- Fixed code style problems.