### PR TITLE
Refactor client-hints, add Permissions-Policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: % dist-clean dist make-zip svn
+.PHONY: % dist-clean dist make-zip svn test check fix
 
 FILE := image-cdn-0.0.0.zip
 
@@ -14,6 +14,15 @@ make-zip:
 	cd dist && zip -9 -r ${FILE} image_cdn
 	rm -rf dist/image_cdn
 
-svn:
-	cp -v -r plugin-assets/* svn/assets/
-	cp -v -r *.php *.txt imageengine assets templates svn/trunk
+test:
+	vendor/bin/phpunit -vvv -c phpunit-standalone.xml.dist
+
+fix:
+	vendor/bin/phpcbf -v
+
+check:
+	vendor/bin/phpcs
+
+# svn:
+# 	cp -v -r plugin-assets/* svn/assets/
+# 	cp -v -r *.php *.txt imageengine assets templates svn/trunk

--- a/image-cdn.php
+++ b/image-cdn.php
@@ -16,7 +16,7 @@
  * Requires PHP:      5.6
  * Text Domain:       image-cdn
  * License:           GPLv2 or later
- * Version:           1.1.0
+ * Version:           1.1.1
  */
 
 // Load plugin files.

--- a/image-cdn.php
+++ b/image-cdn.php
@@ -19,6 +19,12 @@
  * Version:           1.1.1
  */
 
+// Update this then you update "Requires at least" above!
+define( 'IMAGE_CDN_MIN_WP', '4.6' );
+
+// Update this when you update the "Version" above!
+define( 'IMAGE_CDN_VERSION', '1.1.1' );
+
 // Load plugin files.
 require_once __DIR__ . '/imageengine/class-settings.php';
 require_once __DIR__ . '/imageengine/class-rewriter.php';
@@ -29,7 +35,6 @@ defined( 'ABSPATH' ) || exit();
 define( 'IMAGE_CDN_FILE', __FILE__ );
 define( 'IMAGE_CDN_DIR', __DIR__ );
 define( 'IMAGE_CDN_BASE', plugin_basename( __FILE__ ) );
-define( 'IMAGE_CDN_MIN_WP', '3.8' );
 
 add_action( 'plugins_loaded', array( ImageEngine\ImageCDN::class, 'instance' ) );
 register_uninstall_hook( __FILE__, array( ImageEngine\ImageCDN::class, 'handle_uninstall_hook' ) );

--- a/imageengine/class-imagecdn.php
+++ b/imageengine/class-imagecdn.php
@@ -133,7 +133,7 @@ class ImageCDN {
 
 		$permissions = array();
 		foreach (self::$client_hints as $hint) {
-			$permissions[] = strtolower( "ch-${hint}=(${protocol}://${host})" );
+			$permissions[] = strtolower( "ch-${hint}=(\"${protocol}://${host}\")" );
 		}
 		// Add Permissions-Policy header.
 		// This header replaced Feature-Policy in Chrome 88, released in January 2021.

--- a/imageengine/class-imagecdn.php
+++ b/imageengine/class-imagecdn.php
@@ -29,9 +29,9 @@ class ImageCDN {
 		'Viewport-Width',
 		'Width',
 		'DPR',
-		'ECT',
 		/**
 		 * Disabled for CORS compatibility:
+		 * 'ECT',
 		 * 'Device-Memory',
 		 * 'RTT',
 		 * 'Downlink',

--- a/imageengine/class-imagecdn.php
+++ b/imageengine/class-imagecdn.php
@@ -120,20 +120,20 @@ class ImageCDN {
 		$protocol = is_ssl() ? 'https' : 'http';
 
 		// Add Preconnect header
-		self::header( 'Link', "<${protocol}://${host}>; rel=preconnect" );
+		self::header( 'Link', "<{$protocol}://{$host}>; rel=preconnect" );
 
 		// Add Feature-Policy header.
 		// @deprecated in favor of Permissions-Policy and will be removed once adaquate market
 		// adoption has been reached (90-95%).
 		$features = array();
 		foreach ( self::$client_hints as $hint ) {
-			$features[] = strtolower( "ch-${hint} ${protocol}://${host}" );
+			$features[] = strtolower( "ch-{$hint} {$protocol}://{$host}" );
 		}
 		self::header( 'Feature-Policy', strtolower( implode( '; ', $features ) ) );
 
 		$permissions = array();
 		foreach (self::$client_hints as $hint) {
-			$permissions[] = strtolower( "ch-${hint}=(\"${protocol}://${host}\")" );
+			$permissions[] = strtolower( "ch-{$hint}=(\"{$protocol}://{$host}\")" );
 		}
 		// Add Permissions-Policy header.
 		// This header replaced Feature-Policy in Chrome 88, released in January 2021.

--- a/imageengine/class-imagecdn.php
+++ b/imageengine/class-imagecdn.php
@@ -39,6 +39,17 @@ class ImageCDN {
 	);
 
 	/**
+	 * Client hints that do not require CORS preflight confirmation.
+	 *
+	 * @var []string
+	 */
+	private static $safe_client_hints = array(
+		'Viewport-Width',
+		'Width',
+		'DPR',
+	);
+
+	/**
 	 * Singleton Rewriter instance.
 	 *
 	 * @var Rewriter
@@ -197,6 +208,34 @@ class ImageCDN {
 			)
 		);
 	}
+
+	/**
+	 * Gets the list of active client hints.
+	 *
+	 * @return array client hints.
+	 */
+	public static function get_client_hints() {
+		return self::$client_hints;
+	}
+
+	/**
+	 * Gets the list of safe client hints.
+	 *
+	 * @return array client hints.
+	 */
+	public static function get_safe_client_hints() {
+		return self::$safe_client_hints;
+	}
+
+	/**
+	 * Gets the list of active unsafe client hints.
+	 *
+	 * @return array client hints.
+	 */
+	public static function get_unsafe_client_hints() {
+		return array_diff( self::$client_hints, self::$safe_client_hints );
+	}
+
 
 	/**
 	 * Rewrite image URLs in REST API responses

--- a/imageengine/class-imagecdn.php
+++ b/imageengine/class-imagecdn.php
@@ -22,16 +22,20 @@ class ImageCDN {
 
 	/**
 	 * Client hints.
+	 *
+	 * @var []string
 	 */
 	private static $client_hints = array(
 		'Viewport-Width',
 		'Width',
 		'DPR',
 		'ECT',
-		// Disabled for CORS compatibility
-		// 'Device-Memory',
-		// 'RTT',
-		// 'Downlink',
+		/**
+		 * Disabled for CORS compatibility:
+		 * 'Device-Memory',
+		 * 'RTT',
+		 * 'Downlink',
+		 */
 	);
 
 	/**
@@ -43,16 +47,25 @@ class ImageCDN {
 
 	/**
 	 * If true, some functionality will be augmented to facilitate testing.
+	 *
+	 * @internal
+	 * @var bool
 	 */
 	public static $tests_running = false;
 
 	/**
 	 * Captures headers written during unit testing.
+	 *
+	 * @internal
+	 * @var []string
 	 */
 	public static $test_headers_written = array();
 
 	/**
 	 * Options that will be used during unit testing.
+	 *
+	 * @internal
+	 * @var []string
 	 */
 	public static $test_options = array();
 
@@ -69,8 +82,10 @@ class ImageCDN {
 			// Rewrite rendered content in REST API.
 			add_filter( 'the_content', array( self::class, 'rewrite_html' ), 100 );
 
-			// Resource hints.  Note that the 'wp_head' is disabled for the time being due to CORS incompatibility.
-			// add_action( 'wp_head', array( self::class, 'add_head_tags' ), 0 );
+			/**
+			 * Resource hints.  Note that the 'wp_head' is disabled for the time being due to CORS incompatibility.
+			 * add_action( 'wp_head', array( self::class, 'add_head_tags' ), 0 );
+			 */
 			add_action( 'send_headers', array( self::class, 'add_headers' ), 0 );
 
 			// REST API hooks.
@@ -92,6 +107,9 @@ class ImageCDN {
 
 	/**
 	 * Outputs an HTTP header.
+	 *
+	 * @param string $key HTTP header key.
+	 * @param string $value HTTP header value.
 	 */
 	private static function header( $key, $value ) {
 		$val = "$key: $value";
@@ -107,7 +125,6 @@ class ImageCDN {
 	 * Add http headers for Client Hints, Feature Policy and Preconnect Resource Hint.
 	 */
 	public static function add_headers() {
-
 		self::header( 'Accept-CH', strtolower( implode( ', ', self::$client_hints ) ) );
 
 		// Add resource hints and feature policy.
@@ -119,7 +136,7 @@ class ImageCDN {
 
 		$protocol = is_ssl() ? 'https' : 'http';
 
-		// Add Preconnect header
+		// Add Preconnect header.
 		self::header( 'Link', "<{$protocol}://{$host}>; rel=preconnect" );
 
 		// Add Feature-Policy header.
@@ -132,12 +149,12 @@ class ImageCDN {
 		self::header( 'Feature-Policy', strtolower( implode( '; ', $features ) ) );
 
 		$permissions = array();
-		foreach (self::$client_hints as $hint) {
+		foreach ( self::$client_hints as $hint ) {
 			$permissions[] = strtolower( "ch-{$hint}=(\"{$protocol}://{$host}\")" );
 		}
 		// Add Permissions-Policy header.
 		// This header replaced Feature-Policy in Chrome 88, released in January 2021.
-		// @see https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md#appendix-big-changes-since-this-was-called-feature-policy
+		// @see https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md#appendix-big-changes-since-this-was-called-feature-policy .
 		self::header( 'Permissions-Policy', strtolower( implode( ', ', $permissions ) ) );
 	}
 
@@ -147,7 +164,7 @@ class ImageCDN {
 	 */
 	public static function add_head_tags() {
 		// Add client hints.
-		echo '    <meta http-equiv="Accept-CH" content="' . implode( ', ', self::$client_hints ) . '">' . "\n";
+		echo '    <meta http-equiv="Accept-CH" content="' . esc_attr( implode( ', ', self::$client_hints ) ) . '">' . "\n";
 
 		// Add resource hints.
 		$options = self::get_options();

--- a/imageengine/class-rewriter.php
+++ b/imageengine/class-rewriter.php
@@ -115,12 +115,19 @@ class Rewriter {
 	 * @return  boolean  true if need to be excluded.
 	 */
 	public function exclude_asset( $asset ) {
+		$path = strtolower( wp_parse_url( $asset, PHP_URL_PATH ) );
+
 		// Excludes.
 		foreach ( $this->excludes as $exclude ) {
-			if ( $exclude && stripos( $asset, $exclude ) !== false ) {
+			if ( '' === $exclude ) {
+				continue;
+			}
+
+			if ( false !== strpos( $path, strtolower( $exclude ) ) ) {
 				return true;
 			}
 		}
+
 		return false;
 	}
 

--- a/imageengine/class-settings.php
+++ b/imageengine/class-settings.php
@@ -254,16 +254,38 @@ class Settings {
 
 		if ( ! isset( $cdn_res['headers']['content-type'] ) ) {
 			$out['type']    = 'warning';
-			$out['message'] = 'Unable to confirm that the CDN is working properly because it didn\'t send a content type';
+			$out['message'] = 'Unable to confirm that the CDN is working properly because it didn\'t send Content-Type';
 			wp_send_json_error( $out );
 		}
 
 		$cdn_type = $cdn_res['headers']['content-type'];
 		if ( strpos( $cdn_type, 'image/png' ) === false ) {
 			$out['type']    = 'error';
-			$out['message'] = "CDN returned the wrong content type (expected 'image/png', got '$cdn_type'";
+			$out['message'] = "CDN returned the wrong content type (expected 'image/png', got '$cdn_type')";
 			wp_send_json_error( $out );
 		}
+
+		/**
+		 * This check it commented out until we can confirm that it properly tests CORS functionality.
+		 *
+		 * $unsafe_hints = ImageCDN::get_unsafe_client_hints();
+		 * if ( 0 < count( $unsafe_hints ) ) {
+		 *     $cors_error = true;
+		 *     if ( ! array_key_exists( 'access-control-allowed-headers', $cdn_res['headers'] ) ) {
+		 *         $out['type']    = 'warning';
+		 *         $out['message'] = 'Unable to confirm that the CDN supports client-hints because it didn\'t send Access-Control-Allow-Headers.  Fonts may not work if served from the CDN.';
+		 *         wp_send_json_error( $out );
+		 *     }
+		 *
+		 *     $allowed       = preg_split( '/ +/', trim( $cdn_res['headers']['access-control-allowed-headers'] ) );
+		 *     $missing_hints = array_diff( $unsafe_hints, $allowed );
+		 *     if ( 0 < count( $missing_hints ) ) {
+		 *         $out['type']    = 'warning';
+		 *         $out['message'] = 'Unable to confirm that the CDN supports advanced client-hints because it is missing some active client-hints in Access-Control-Allow-Headers (' . implode( ',', $missing_hints ) . ').  Fonts may not work if served from the CDN.';
+		 *         wp_send_json_error( $out );
+		 *     }
+		 * }
+		 */
 
 		$out['type']    = 'success';
 		$out['message'] = 'Test successful';

--- a/readme.txt
+++ b/readme.txt
@@ -122,7 +122,7 @@ Upgrades can be performed in the normal WordPress way, nothing else will need to
 
 = 1.1.1 =
 * Improved CORS compatibility
-* Removed downlink hint
+* Removed downlink and ect hint
 * Added Permissions-Policy header
 
 = 1.1.0 =

--- a/readme.txt
+++ b/readme.txt
@@ -120,6 +120,11 @@ Upgrades can be performed in the normal WordPress way, nothing else will need to
 
 == Changelog ==
 
+= 1.1.1 =
+* Improved CORS compatibility
+* Removed downlink hint
+* Added Permissions-Policy header
+
 = 1.1.0 =
 * Fixed compatibility issue with Divi
 * Increased performance

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -18,11 +18,11 @@
 			);
 			?>
 		</p>
-		<p><?php esc_html_e( 'To obtain an ImageEngine Delivery Address' ); ?>:</p>
+		<p><?php esc_html_e( 'To obtain an ImageEngine Delivery Address:' ); ?></p>
 		<ol>
 			<li><a target="_blank" href="https://imageengine.io/signup/?website=<?php echo esc_attr( get_site_url() ); ?>&?utm_source=WP-plugin-settigns&utm_medium=page&utm_term=wp-imageengine&utm_campaign=wp-imageengine">Sign up for an ImageEngine account</a></li>
 			<li>
-			<?php
+				<?php
 				printf(
 					// translators: 1: http code example 2: https code example.
 					esc_html__( 'Enter the assigned ImageEngine Delivery Address (including %1$s or %2$s) in the "CDN URL" option below.', 'image-cdn' ),
@@ -34,7 +34,15 @@
 		</ol>
 		<p>See <a href="https://imageengine.io/docs/setup/quick-start/?utm_source=WP-plugin-settigns&utm_medium=page&utm_term=wp-imageengine&utm_campaign=wp-imageengine" target="_blank">full documentation.</a></p>
 	</div>
-	<h2><?php esc_html_e( 'Image CDN Settings', 'image-cdn' ); ?></h2>
+	<h2>
+		<?php
+		printf(
+			// translators: %s is the plugin version number.
+			'Image CDN Settings (version %s)',
+			esc_attr( IMAGE_CDN_VERSION )
+		)
+		?>
+	</h2>
 	<?php if ( $options['enabled'] && ! $is_runnable ) { ?>
 		<div class="notice notice-error">
 			<p>
@@ -119,11 +127,11 @@
 					<fieldset>
 						<label for="image_cdn_dirs">
 							<input type="text" name="image_cdn[dirs]" id="image_cdn_dirs" value="<?php echo esc_attr( $options['dirs'] ); ?>" size="64" class="regular-text code" />
-							<?php esc_html_e( 'Default', 'image-cdn' ); ?>: <code><?php echo esc_html( $defaults['dirs'] ); ?></code>
+							<?php esc_html_e( 'Optional; Default:', 'image-cdn' ); ?> <code><?php echo esc_html( $defaults['dirs'] ); ?></code>
 						</label>
 
 						<p class="description">
-							<?php esc_html_e( 'Assets in these directories will be pointed to the CDN URL. Enter the directories separated by', 'image-cdn' ); ?> <code>,</code>
+							<?php esc_html_e( 'Assets in these directories will be served by the CDN. Enter the directories separated by', 'image-cdn' ); ?> <code>,</code>
 						</p>
 					</fieldset>
 				</td>

--- a/tests/standalone/bootstrap.php
+++ b/tests/standalone/bootstrap.php
@@ -17,3 +17,11 @@ require_once __DIR__ . '/../../imageengine/class-imagecdn.php';
 function is_admin_bar_showing() {
 	return false;
 }
+
+function wp_parse_url($url, $flags) {
+	return parse_url($url, $flags);
+}
+
+function is_ssl() {
+	return true;
+}

--- a/tests/standalone/test-imagecdn.php
+++ b/tests/standalone/test-imagecdn.php
@@ -22,10 +22,10 @@ class ImageCDNTest extends PHPUnit_Framework_TestCase {
         ImageCDN::add_headers();
 
         $expected = [
-            'Accept-CH: viewport-width, width, dpr, ect',
+            'Accept-CH: viewport-width, width, dpr',
             'Link: <https://foo.com>; rel=preconnect',
-            'Feature-Policy: ch-viewport-width https://foo.com; ch-width https://foo.com; ch-dpr https://foo.com; ch-ect https://foo.com',
-            'Permissions-Policy: ch-viewport-width=("https://foo.com"), ch-width=("https://foo.com"), ch-dpr=("https://foo.com"), ch-ect=("https://foo.com")',
+            'Feature-Policy: ch-viewport-width https://foo.com; ch-width https://foo.com; ch-dpr https://foo.com',
+            'Permissions-Policy: ch-viewport-width=("https://foo.com"), ch-width=("https://foo.com"), ch-dpr=("https://foo.com")',
         ];
         $this->assertSame($expected, ImageCDN::$test_headers_written);
     }

--- a/tests/standalone/test-imagecdn.php
+++ b/tests/standalone/test-imagecdn.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * This file contains standalone tests for the ImageCDN functionality
+ *
+ * @package ImageCDN
+ */
+
+use ImageEngine\ImageCDN;
+
+/**
+ * The ImageCDNTest class tests the ImageCDN class.
+ */
+class ImageCDNTest extends PHPUnit_Framework_TestCase {
+
+    public function testAddHeaders() {
+        ImageCDN::$tests_running = true;
+        ImageCDN::$test_headers_written = [];
+        ImageCDN::$test_options = [
+            'url' => 'https://foo.com',
+        ];
+
+        ImageCDN::add_headers();
+
+        $expected = [
+            'Accept-CH: viewport-width, width, dpr, ect',
+            'Link: <https://foo.com>; rel=preconnect',
+            'Feature-Policy: ch-viewport-width https://foo.com; ch-width https://foo.com; ch-dpr https://foo.com; ch-ect https://foo.com',
+            'Permissions-Policy: ch-viewport-width=("https://foo.com"), ch-width=("https://foo.com"), ch-dpr=("https://foo.com"), ch-ect=("https://foo.com")',
+        ];
+        $this->assertSame($expected, ImageCDN::$test_headers_written);
+    }
+}

--- a/tests/standalone/test-rewriter.php
+++ b/tests/standalone/test-rewriter.php
@@ -20,15 +20,17 @@ class RewriterTest extends PHPUnit_Framework_TestCase {
 		$cdn_url    = 'http://my.cdn';
 		$path       = '';
 		$dirs       = 'wp-includes';
-		$excludes   = array( '.php' );
+		$excludes   = array( '.php', '.woff2' );
 		$relative   = true;
 		$https      = true;
 		$directives = '/cmpr_20';
 
 		$rewrite = new Rewriter( $blog_url, $cdn_url, $path, $dirs, $excludes, $relative, $https, $directives );
 
-		$this->assertEquals( true, $rewrite->exclude_asset( '/wp-includes/bar.php' ) );
-		$this->assertEquals( true, $rewrite->exclude_asset( '/wp-includes/bar.php/foo.jpg' ) );
+		$this->assertEquals( true,  $rewrite->exclude_asset( '/wp-includes/bar.php' ) );
+		$this->assertEquals( true,  $rewrite->exclude_asset( '/wp-includes/bar.woff2' ) );
+		$this->assertEquals( false, $rewrite->exclude_asset( '/wp-includes/bar.woff' ) );
+		$this->assertEquals( true,  $rewrite->exclude_asset( '/wp-includes/bar.php/foo.jpg' ) );
 		$this->assertEquals( false, $rewrite->exclude_asset( '/wp-includes/bar.jpg' ) );
 	}
 


### PR DESCRIPTION
This PR reworks the Client-Hints / CORS﻿-support headers so all code uses the same set of client-hints.

It also implements `Permissions-Policy`, the replacement for `Feature-Policy` as of Chrome 88
For more info see:
- https://github.com/w3c/webappsec-permissions-policy/pull/379
- https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md#appendix-big-changes-since-this-was-called-feature-policy
- https://w3c.github.io/webappsec-permissions-policy/#permissions-policy-http-header-field