### PR TITLE
Confirmed WP 5.7 compat, moved from jQuery to Fetch API

### DIFF
--- a/image-cdn.php
+++ b/image-cdn.php
@@ -16,14 +16,14 @@
  * Requires PHP:      5.6
  * Text Domain:       image-cdn
  * License:           GPLv2 or later
- * Version:           1.1.1
+ * Version:           1.1.2
  */
 
 // Update this then you update "Requires at least" above!
 define( 'IMAGE_CDN_MIN_WP', '4.6' );
 
 // Update this when you update the "Version" above!
-define( 'IMAGE_CDN_VERSION', '1.1.1' );
+define( 'IMAGE_CDN_VERSION', '1.1.2' );
 
 // Load plugin files.
 require_once __DIR__ . '/imageengine/class-settings.php';

--- a/imageengine/class-settings.php
+++ b/imageengine/class-settings.php
@@ -137,28 +137,33 @@ class Settings {
 				}
 
 				document.querySelector('#check-cdn').addEventListener('click', () => {
-					show_test_results({'type': 'info'})
+					show_test_results({
+						'type': 'info'
+					})
 
 					window.scrollTo({
 						top: 50,
 						left: 0,
 						behavior: 'smooth',
-					});
+					})
 
-					const data = {
-						'action': 'image_cdn_test_config',
-						'nonce': '<?php echo esc_js( $nonce ); ?>',
-						'cdn_url': document.querySelector('#image_cdn_url').value,
-						'path': document.querySelector('#image_cdn_path').value,
-					}
-					console.log(data)
-
-					const success = response => show_test_results(response.data)
-
-					jQuery.post(ajaxurl, data, success, 'json')
-						.fail((jqXHR, status) => {
-							show_test_results('error', 'unable to start test: ' + status)
+					fetch(ajaxurl, {
+							method: 'POST',
+							credentials: 'same-origin',
+							headers: new Headers({
+								'accept': 'application/json',
+								'content-type': 'application/x-www-form-urlencoded; charset=utf-8',
+							}),
+							body: new URLSearchParams({
+								'action': 'image_cdn_test_config',
+								'nonce': '<?php echo esc_js( $nonce ); ?>',
+								'cdn_url': document.querySelector('#image_cdn_url').value,
+								'path': document.querySelector('#image_cdn_path').value,
+							}),
 						})
+						.then(res => res.json())
+						.then(res => show_test_results(res.data))
+						.catch(err => show_test_results('error', 'unable to start test: ' + err))
 				})
 			})
 		</script>

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: imageengine
 Tags: image cdn, cdn, ImageEngine, image optimization, content delivery network, content distribution network
 Requires at least: 4.6
-Tested up to: 5.6
+Tested up to: 5.7
 Requires PHP: 5.6
 Stable tag: trunk
 License: GPLv2 or later
@@ -119,6 +119,10 @@ Upgrades can be performed in the normal WordPress way, nothing else will need to
 
 
 == Changelog ==
+
+= 1.1.2 =
+* Confirmed WordPress 5.7 compatibility
+* Switched from jQuery to Javascript's fetch API
 
 = 1.1.1 =
 * Improved CORS compatibility


### PR DESCRIPTION
- Confirmed WordPress 5.7 support﻿
- Replaced jQuery with Fetch API