### PR TITLE
Refactor WordPress subdir installation support

### DIFF
--- a/image-cdn.php
+++ b/image-cdn.php
@@ -16,14 +16,14 @@
  * Requires PHP:      5.6
  * Text Domain:       image-cdn
  * License:           GPLv2 or later
- * Version:           1.1.2
+ * Version:           1.1.3
  */
 
 // Update this then you update "Requires at least" above!
 define( 'IMAGE_CDN_MIN_WP', '4.6' );
 
 // Update this when you update the "Version" above!
-define( 'IMAGE_CDN_VERSION', '1.1.2' );
+define( 'IMAGE_CDN_VERSION', '1.1.3' );
 
 // Load plugin files.
 require_once __DIR__ . '/imageengine/class-settings.php';

--- a/imageengine/class-imagecdn.php
+++ b/imageengine/class-imagecdn.php
@@ -329,16 +329,13 @@ class ImageCDN {
 	 * @return array Default options.
 	 */
 	public static function default_options() {
-		$url = self::get_url_path();
+		$url_parts = wp_parse_url( get_option( 'home' ), -1 );
 
-		$content_url   = self::get_url_path( content_url() );
-		$includes_url  = self::get_url_path( includes_url() );
-		$content_path  = trim( $content_url['path'], '/' );
-		$includes_path = trim( $includes_url['path'], '/' );
+		$content_path   = trim(wp_parse_url( content_url(), PHP_URL_PATH ), '/');
+		$includes_path  = trim(wp_parse_url( includes_url(), PHP_URL_PATH ), '/');
 
 		return array(
-			'url'        => $url['base'],
-			'path'       => $url['path'],
+			'url'        => $url_parts['scheme'] . '://' . $url_parts['host'],
 			'dirs'       => implode( ',', array( $content_path, $includes_path ) ),
 			'excludes'   => '.php',
 			'relative'   => true,
@@ -394,32 +391,6 @@ class ImageCDN {
 	}
 
 	/**
-	 * Split the WP home URL into base URL and path components.
-	 *
-	 * @param string $url Input URL.
-	 * @return array Array of components with keys 'url', 'base' and 'path'.
-	 */
-	public static function get_url_path( $url = '' ) {
-		if ( '' === $url ) {
-			$url = get_option( 'home' );
-		}
-
-		$base_url = $url;
-		$path     = '';
-
-		if ( preg_match( '#^(https?://[^/]+)(/.*)$#', $url, $matches ) ) {
-			$base_url = $matches[1];
-			$path     = $matches[2];
-		}
-
-		return array(
-			'url'  => $url,
-			'base' => $base_url,
-			'path' => $path,
-		);
-	}
-
-	/**
 	 * Return new rewriter.
 	 */
 	public static function get_rewriter() {
@@ -430,7 +401,6 @@ class ImageCDN {
 			self::$rewriter = new Rewriter(
 				get_option( 'home' ),
 				$options['url'],
-				$options['path'],
 				$options['dirs'],
 				$excludes,
 				$options['relative'],

--- a/imageengine/class-imagecdn.php
+++ b/imageengine/class-imagecdn.php
@@ -329,13 +329,11 @@ class ImageCDN {
 	 * @return array Default options.
 	 */
 	public static function default_options() {
-		$url_parts = wp_parse_url( get_option( 'home' ), -1 );
-
 		$content_path  = trim( wp_parse_url( content_url(), PHP_URL_PATH ), '/' );
 		$includes_path = trim( wp_parse_url( includes_url(), PHP_URL_PATH ), '/' );
 
 		return array(
-			'url'        => $url_parts['scheme'] . '://' . $url_parts['host'],
+			'url'        => '',
 			'dirs'       => implode( ',', array( $content_path, $includes_path ) ),
 			'excludes'   => '.php',
 			'relative'   => true,

--- a/imageengine/class-imagecdn.php
+++ b/imageengine/class-imagecdn.php
@@ -339,7 +339,7 @@ class ImageCDN {
 			'dirs'       => implode( ',', array( $content_path, $includes_path ) ),
 			'excludes'   => '.php',
 			'relative'   => true,
-			'https'      => false,
+			'https'      => true,
 			'directives' => '',
 			'enabled'    => false,
 		);

--- a/imageengine/class-imagecdn.php
+++ b/imageengine/class-imagecdn.php
@@ -331,8 +331,8 @@ class ImageCDN {
 	public static function default_options() {
 		$url_parts = wp_parse_url( get_option( 'home' ), -1 );
 
-		$content_path   = trim(wp_parse_url( content_url(), PHP_URL_PATH ), '/');
-		$includes_path  = trim(wp_parse_url( includes_url(), PHP_URL_PATH ), '/');
+		$content_path  = trim( wp_parse_url( content_url(), PHP_URL_PATH ), '/' );
+		$includes_path = trim( wp_parse_url( includes_url(), PHP_URL_PATH ), '/' );
 
 		return array(
 			'url'        => $url_parts['scheme'] . '://' . $url_parts['host'],

--- a/imageengine/class-rewriter.php
+++ b/imageengine/class-rewriter.php
@@ -21,22 +21,17 @@ class Rewriter {
 
 	/**
 	 * WordPress installation scheme (http or https).
+	 *
+	 * @var string
 	 */
 	public $blog_scheme;
 
 	/**
 	 * CDN URL.
 	 *
-	 * @var str
-	 */
-	public $cdn_url;
-
-	/**
-	 * Path / subdirectory of the WordPress installation, if not '/'.
-	 *
 	 * @var string
 	 */
-	public $path;
+	public $cdn_url;
 
 	/**
 	 * Included directories.
@@ -48,7 +43,7 @@ class Rewriter {
 	/**
 	 * Excludes.
 	 *
-	 * @var arra
+	 * @var array
 	 */
 	public $excludes = array();
 
@@ -85,7 +80,6 @@ class Rewriter {
 	 *
 	 * @param string $blog_url WordPress installation URL.
 	 * @param string $cdn_url CDN URL.
-	 * @param string $path Path / subdirectory of the WordPress installation, if not '/'.
 	 * @param string $dirs Included directories.
 	 * @param array  $excludes Excludes.
 	 * @param bool   $relative Use CDN on relative paths.
@@ -102,17 +96,16 @@ class Rewriter {
 		$directives
 	) {
 
-		// Separate the path component from the base URL (scheme://domain)
-		$url_parts = wp_parse_url($blog_url, -1);
-		$this->blog_domain = strtolower($url_parts['host']);
-		$this->blog_scheme = strtolower($url_parts['scheme']);
-		$this->path = array_key_exists('path', $url_parts)? $url_parts['path']: '';
-		$this->cdn_url    = $cdn_url;
-		$this->dirs       = $dirs;
-		$this->excludes   = $excludes;
-		$this->relative   = $relative;
-		$this->https      = $https;
-		$this->directives = $directives;
+		// Separate the path component from the base URL (scheme://domain).
+		$url_parts         = wp_parse_url( $blog_url, -1 );
+		$this->blog_domain = strtolower( $url_parts['host'] );
+		$this->blog_scheme = strtolower( $url_parts['scheme'] );
+		$this->cdn_url     = $cdn_url;
+		$this->dirs        = $dirs;
+		$this->excludes    = $excludes;
+		$this->relative    = $relative;
+		$this->https       = $https;
+		$this->directives  = $directives;
 	}
 
 
@@ -169,7 +162,7 @@ class Rewriter {
 			return $asset_url;
 		}
 
-		$blog_url = "//" . $this->blog_domain;
+		$blog_url   = '//' . $this->blog_domain;
 		$subst_urls = array( 'http:' . $blog_url );
 
 		// Rewrite both http and https URLs if we ticked 'enable CDN for HTTPS connections'.

--- a/imageengine/class-settings.php
+++ b/imageengine/class-settings.php
@@ -58,18 +58,10 @@ class Settings {
 			}
 		}
 
-		$clean_dirs = [];
-		foreach (explode(',', $data['dirs']) as $dir) {
-			$dir = trim($dir);
-			if ('' === $dir || in_array($dir, $clean_dirs)) continue;
-			$clean_dirs[] = $dir;
-		}
-		$data['dirs'] = implode(',', $clean_dirs);
-
 		return array(
 			'url'        => esc_url_raw( $data['url'] ),
-			'dirs'       => esc_attr( $data['dirs'] ),
-			'excludes'   => esc_attr( $data['excludes'] ),
+			'dirs'       => esc_attr( self::clean_list( $data['dirs'] ) ),
+			'excludes'   => esc_attr( self::clean_list( $data['excludes'] ) ),
 			'relative'   => (bool) $data['relative'],
 			'https'      => (bool) $data['https'],
 			'directives' => self::clean_directives( $data['directives'] ),
@@ -78,9 +70,29 @@ class Settings {
 	}
 
 	/**
+	 * Cleans a $delimiter-separated list by trimming each element and rejoining them and removing empty and duplicate elements.
+	 *
+	 * @param string $list list of strings separated by $delimiter.
+	 * @param string $delimiter delimiter.
+	 * @return string list of strings.
+	 */
+	public static function clean_list( $list, $delimiter = ',' ) {
+		$clean = array();
+		foreach ( explode( $delimiter, $list ) as $dir ) {
+			$dir = trim( $dir );
+			if ( '' === $dir || in_array( $dir, $clean, true ) ) {
+				continue;
+			}
+			$clean[] = $dir;
+		}
+		return implode( $delimiter, $clean );
+	}
+
+	/**
 	 * Clean the ImageEngine Directives.
 	 *
 	 * @param string $directives ImageEngine Directives as a comma-separated list.
+	 * @return string ImageEngine Directives.
 	 */
 	public static function clean_directives( $directives ) {
 		$directives = preg_replace( '#.*imgeng=/+?#', '', $directives );

--- a/imageengine/class-settings.php
+++ b/imageengine/class-settings.php
@@ -37,23 +37,32 @@ class Settings {
 			$data['https'] = 0;
 		}
 
-		$data['url'] = rtrim( $data['url'], '/' );
+		$data['relative'] = (bool) $data['relative'];
+		$data['https'] = (bool) $data['https'];
+		$data['enabled'] = (bool) $data['enabled'];
 
-		$parts = wp_parse_url( $data['url'] );
-		if ( ! isset( $parts['scheme'] ) || ! isset( $parts['host'] ) ) {
-			add_settings_error( 'url', 'url', 'Invalid URL: Missing scheme (<code>http://</code> or <code>https://</code>) or hostname' );
+		$data['url'] = trim( rtrim( $data['url'], '/' ) );
+
+		if ( '' === $data['url'] ) {
+			add_settings_error( 'url', 'url', 'The Delivery Address is required' );
 		} else {
 
-			// Make sure there is a valid scheme.
-			if ( ! in_array( $parts['scheme'], array( 'http', 'https' ), true ) ) {
-				add_settings_error( 'url', 'url', 'Invalid URL: Must begin with <code>http://</code> or <code>https://</code>' );
-			}
+			$parts = wp_parse_url( $data['url'] );
+			if ( ! isset( $parts['scheme'] ) || ! isset( $parts['host'] ) ) {
+				add_settings_error( 'url', 'url', 'Delivery Address must begin with <code>http://</code> or <code>https://</code>' );
+			} else {
 
-			// Make sure the host is resolves.
-			if ( ! filter_var( $parts['host'], FILTER_VALIDATE_IP ) ) {
-				$ip = gethostbyname( $parts['host'] );
-				if ( $ip === $parts['host'] ) {
-					add_settings_error( 'url', 'url', 'Invalid URL: Could not resolve hostname' );
+				// Make sure there is a valid scheme.
+				if ( ! in_array( $parts['scheme'], array( 'http', 'https' ), true ) ) {
+					add_settings_error( 'url', 'url', 'Delivery Address must begin with <code>http://</code> or <code>https://</code>' );
+				}
+
+				// Make sure the host is resolves.
+				if ( ! filter_var( $parts['host'], FILTER_VALIDATE_IP ) ) {
+					$ip = gethostbyname( $parts['host'] );
+					if ( $ip === $parts['host'] ) {
+						add_settings_error( 'url', 'url', 'Invalid URL: Could not resolve hostname' );
+					}
 				}
 			}
 		}
@@ -62,10 +71,10 @@ class Settings {
 			'url'        => esc_url_raw( $data['url'] ),
 			'dirs'       => esc_attr( self::clean_list( $data['dirs'] ) ),
 			'excludes'   => esc_attr( self::clean_list( $data['excludes'] ) ),
-			'relative'   => (bool) $data['relative'],
-			'https'      => (bool) $data['https'],
+			'relative'   => $data['relative'],
+			'https'      => $data['https'],
 			'directives' => self::clean_directives( $data['directives'] ),
-			'enabled'    => (bool) $data['enabled'],
+			'enabled'    => $data['enabled'],
 		);
 	}
 

--- a/imageengine/class-settings.php
+++ b/imageengine/class-settings.php
@@ -58,14 +58,16 @@ class Settings {
 			}
 		}
 
-		$data['path'] = trim( $data['path'], '/' );
-		if ( strlen( $data['path'] ) > 0 ) {
-			$data['path'] = '/' . $data['path'];
+		$clean_dirs = [];
+		foreach (explode(',', $data['dirs']) as $dir) {
+			$dir = trim($dir);
+			if ('' === $dir || in_array($dir, $clean_dirs)) continue;
+			$clean_dirs[] = $dir;
 		}
+		$data['dirs'] = implode(',', $clean_dirs);
 
 		return array(
 			'url'        => esc_url_raw( $data['url'] ),
-			'path'       => $data['path'],
 			'dirs'       => esc_attr( $data['dirs'] ),
 			'excludes'   => esc_attr( $data['excludes'] ),
 			'relative'   => (bool) $data['relative'],
@@ -192,7 +194,6 @@ class Settings {
 								'action': 'image_cdn_test_config',
 								'nonce': '<?php echo esc_js( $nonce ); ?>',
 								'cdn_url': document.getElementById('image_cdn_url').value,
-								'path': document.getElementById('image_cdn_path').value,
 							}),
 						})
 						.then(res => res.json())
@@ -254,7 +255,6 @@ class Settings {
 		$asset        = 'assets/logo.png';
 		$local_url    = plugin_dir_url( IMAGE_CDN_FILE ) . $asset;
 		$cdn_base_url = trim( esc_url_raw( wp_unslash( $_POST['cdn_url'] ) ), '/' );
-		$path         = array_key_exists( 'path', $_POST ) ? sanitize_text_field( wp_unslash( $_POST['path'] ) ) : '';
 
 		$plugin_path = wp_parse_url( plugin_dir_url( IMAGE_CDN_FILE ), PHP_URL_PATH );
 
@@ -263,7 +263,6 @@ class Settings {
 
 		$parts = array(
 			$cdn_base_url,
-			$path,
 			$plugin_path,
 			$asset,
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -120,6 +120,10 @@ Upgrades can be performed in the normal WordPress way, nothing else will need to
 
 == Changelog ==
 
+= 1.1.3 =
+* Simplify handling of WP installations within subdirectories
+* Automatically detect path setting and remove it from the settings page
+
 = 1.1.2 =
 * Confirmed WordPress 5.7 compatibility
 * Switched from jQuery to Javascript's fetch API

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
-=== Image CDN - WordPress CDN Plugin ===
+=== ImageEngine Optimizer CDN – Convert to WebP & AVIF ===
 Contributors: imageengine
-Tags: image cdn, cdn, ImageEngine, image optimization, content delivery network, content distribution network
+Tags: image cdn, cdn, ImageEngine, image optimizer, content delivery network, image convert, avif, webp
 Requires at least: 4.6
 Tested up to: 5.7
 Requires PHP: 5.6
@@ -8,30 +8,28 @@ Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Enable CDN URLs for your static assets such as images, CSS or JavaScript files.
 
 == Description ==
 
-[ImageEngine’s Image CDN](https://imageengine.io/?utm_source=wordpress.org&utm_medium=page&utm_term=wp-imageengine&utm_campaign=wp-imageengine) plugin accelerates your WordPress or WooCommerce performance by optimizing static images and other assets and delivering them through the ImageEngine content delivery network. The plugin automatically tailors images specifically to the end user's smartphone, tablet or desktop device model and browser, converts them to an optimal image format (e.g. WebP or JPEG 2000), and delivers them via a CDN. To use this plugin with the ImageEngine CDN, get a [free trial account here](https://imageengine.io/signup?utm_source=wordpress.org&utm_medium=page&utm_term=wp-imageengine&utm_campaign=wp-imageengine).
+[ImageEngine’s Image CDN](https://imageengine.io/?utm_source=wordpress.org&utm_medium=page&utm_term=wp-imageengine&utm_campaign=wp-imageengine) plugin accelerates your WordPress or WooCommerce performance by optimizing images, converting them to WebP, JPEG2000, or AVIF, and delivering them through the ImageEngine content delivery network. The result is smaller image payload, faster page loading, improved Google PageSpeed Insights scores (Speed Index, Largest Contentful Paint, Time to Interactive), and a better user experience leading to more conversions or sales. To use this plugin with the ImageEngine Optimizer CDN, get a [free trial account here](https://imageengine.io/signup?utm_source=wordpress.org&utm_medium=page&utm_term=wp-imageengine&utm_campaign=wp-imageengine).
+
+https://vimeo.com/496085924
 
 = How ImageEngine Works =
 
-The plugin works by rewriting the URLs to your assets (images, javascript, css, etc), switching your domain for the CDN's domain. Unlike other CDN plugins, the Image CDN plugin makes it simple to test your configuration before enabling it.
+This plugin rewrites your image URLs to include the ImageEngine Delivery Address you recieve when you sign up for an ImageEngine account. This rewrite will allow ImageEngine to access your original images, instantly optimize and convert them, and deliver via the ImageEngine CDN. After configuring and enabling the plug in, image are delivered this way:
 
-* When a visitor requests a page, ImageEngine dynamically pulls images from your WordPress origin and optimizes them.
-* At the CDN edge, ImageEngine uses device detection to identify the requesting devices and browser characteristics.
-* Based on this information, ImageEngine will resize, compress and encode images so they are best suited to the end users' device.
-* The optimized image will then be delivered at the ImageEngine CDN edge. Subsequent requests are served instantly with cached assets stored on ImageEngine’s global CDN.
-
-Users of [ImageEngine](https://imageengine.io/?utm_source=wordpress.org&utm_medium=page&utm_term=wp-imageengine&utm_campaign=wp-imageengine) can also configure the Directives for their assets to control image quality, automatic format conversion and automatic image resizing.
+* When a visitor requests an image, ImageEngine CDN servers use client hints or device detection to identify the requesting devices and browser characteristics.
+* Based on the browser characteristics, ImageEngine will resize, compress and convert images to WebP, JPEG 2000, or AVIF.
+* The optimized image is  delivered from the ImageEngine CDN edge. Subsequent requests are served instantly with WebP, JPEG 2000, or AVIF images stored on ImageEngine’s global CDN.
 
 = What Makes ImageEngine Better Than Other CDNs or Digital Asset Management Platforms? =
 
-* Delivers optimized images 30% faster than other CDNs or Digital Asset Management platforms.
+* Delivers optimized WebP, JPEG 2000, or AVIF images 30% faster than other CDNs or Digital Asset Management platforms.
 * Achieves up to 80% image payload reduction with no perceptible change in quality.
 * Simple to install. Easy to test your configuration before enabling it. No need to move or upload images.
-* Only CDN with true device-aware edge servers to drive superior, fine-tuned optimization.
-* Automatic image optimization of JPG, PNG, GIF, SVG, BMP, TIF into next generation formats like WebP, JPEG 2000, aWebP, or MP4. You can also safely serve non-image files through ImageEngine.
+* Only CDN with true device-aware edge servers to drive superior, fine-tuned image optimization.
+* Automatic image optimization of JPG, PNG, GIF, SVG, BMP, TIF into next generation formats like WebP, JPEG 2000, AVIF, Animated WebP, or MP4. You can also safely serve non-image files through ImageEngine.
 * Delivers via its scalable global CDN network, with support for HTTPS, HTTP/2, WAF, and DDoS protection.
 
 = Support Resources =
@@ -53,17 +51,17 @@ You can get started with ImageEngine easily with a [free, no credit card require
 * **Standard** - $99/month. Up to **250 GB** per month. Includes 3 custom domains (CNAME) with HTTPS support. Priority onboarding support.
 * **Pro** - pricing scales with usage volume.  WAF with DDoS protection. Dedicated edge servers available. Ticketed enterprise support. [Contact us](https://imageengine.io/contact?utm_source=wordpress.org&utm_medium=page&utm_term=wp-imageengine&utm_campaign=wp-imageengine).
 
-= Features =
+= Features & BENEFITS=
 
-* Maximize web performance by serving static assets from a CDN
+* Maximize web performance by automatically serving optimized WebP, JPEG 2000, or AVIF images  from a CDN
 * Set the WordPress directories that should be included
 * Custom filters "image_cdn_url" and "image_cdn_html" included
 * Define excluded directories or extensions
 * Enable or disable HTTPS support
 * Turn on or off quickly without deactivating the plugin
 * Test the CDN integration before saving your changes to make sure it will work properly
-* Supports [ImageEngine Directives](https://imageengine.io/docs/implementation/directives/?utm_source=wordpress.org&utm_medium=page&utm_term=wp-imageengine&utm_campaign=wp-imageengine)
-* Compatible with the [WordPress Cache Enabler](https://wordpress.org/plugins/cache-enabler/) plugin
+* Supports [ImageEngine Directives](https://imageengine.io/docs/implementation/directives/?utm_source=wordpress.org&utm_medium=page&utm_term=wp-imageengine&utm_campaign=wp-imageengine). Users of ImageEngine can also configure the Directives for their assets to control image quality, automatic format conversion and automatic image resizing.
+* Compatible with the [WordPress Cache Enabler](https://wordpress.org/plugins/cache-enabler/) plugin, WooCommerce, Elementor and other popular plugins.
 
 == System Requirements ==
 
@@ -84,7 +82,7 @@ The following are the steps to install the Image CDN plugin
 2. Type `ImageEngine` in the search box in the top right corner.
 3. Click the "Install Now" button on the Image CDN – WordPress CDN Plugin.
 4. Activate the plugin
-4. Go to Settings -> Image CDN and follow in the instructions on how to enable the service.
+4. Go to `Settings` -> `Image CDN` and follow in the instructions on how to enable the service.
 
 
 == Frequently Asked Questions ==

--- a/readme.txt
+++ b/readme.txt
@@ -21,7 +21,7 @@ This plugin rewrites your image URLs to include the ImageEngine Delivery Address
 
 * When a visitor requests an image, ImageEngine CDN servers use client hints or device detection to identify the requesting devices and browser characteristics.
 * Based on the browser characteristics, ImageEngine will resize, compress and convert images to WebP, JPEG 2000, or AVIF.
-* The optimized image is  delivered from the ImageEngine CDN edge. Subsequent requests are served instantly with WebP, JPEG 2000, or AVIF images stored on ImageEngine’s global CDN.
+* The optimized image is delivered from the nearest ImageEngine CDN region. Subsequent requests are served instantly with WebP, JPEG 2000, or AVIF images and stored on ImageEngine's global CDN.
 
 = What Makes ImageEngine Better Than Other CDNs or Digital Asset Management Platforms? =
 

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -96,38 +96,13 @@
 
 			<tr valign="top">
 				<th scope="row">
-					<?php esc_html_e( 'WordPress URL Path', 'image-cdn' ); ?>
-				</th>
-				<td>
-					<fieldset>
-						<label for="image_cdn_path">
-							<input type="text" name="image_cdn[path]" id="image_cdn_path" value="<?php echo esc_attr( $options['path'] ); ?>" size="64" class="regular-text code" />
-							<?php esc_html_e( 'Optional', 'image-cdn' ); ?>
-						</label>
-
-						<p class="description">
-							<?php
-							printf(
-								// translators: 1: URL code example 2: Path component code example.
-								esc_html__( 'Path/subdirectory that WordPress is installed at.  For example, if WordPress is installed at %1$s, you would enter %2$s.  This is normally auto-detected properly, and is usually empty.', 'image-cdn' ),
-								'<code>https://foo.bar.com/blog</code>',
-								'<code>blog</code>'
-							);
-							?>
-						</p>
-					</fieldset>
-				</td>
-			</tr>
-
-			<tr valign="top">
-				<th scope="row">
 					<?php esc_html_e( 'Included Directories', 'image-cdn' ); ?>
 				</th>
 				<td>
 					<fieldset>
 						<label for="image_cdn_dirs">
 							<input type="text" name="image_cdn[dirs]" id="image_cdn_dirs" value="<?php echo esc_attr( $options['dirs'] ); ?>" size="64" class="regular-text code" />
-							<?php esc_html_e( 'Optional; Default:', 'image-cdn' ); ?> <code><?php echo esc_html( $defaults['dirs'] ); ?></code>
+							<?php esc_html_e( 'Default:', 'image-cdn' ); ?> <code><?php echo esc_html( $defaults['dirs'] ); ?></code>
 						</label>
 
 						<p class="description">

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -46,7 +46,7 @@
 	<?php if ( $options['enabled'] && ! $is_runnable ) { ?>
 		<div class="notice notice-error">
 			<p>
-				<?php esc_html_e( 'Image CDN support is disabled because there is something wrong with your configuration.  Please verify the URL below.', 'image-cdn' ); ?>
+				<?php esc_html_e( 'ImageEngine is disabled because there is something wrong with your configuration.  Please verify the URL below.', 'image-cdn' ); ?>
 			</p>
 		</div>
 	<?php } ?>
@@ -55,24 +55,9 @@
 		<?php settings_fields( 'image_cdn' ); ?>
 
 		<table class="form-table">
-
 			<tr valign="top">
 				<th scope="row">
-					<?php esc_html_e( 'Enabled', 'image-cdn' ); ?>
-				</th>
-				<td>
-					<fieldset>
-						<label for="image_cdn_enabled">
-							<input type="checkbox" name="image_cdn[enabled]" id="image_cdn_enabled" value="1" <?php checked( 1, $options['enabled'] ); ?> />
-							<?php esc_html_e( 'Enable CDN support.', 'image-cdn' ); ?>
-						</label>
-					</fieldset>
-				</td>
-			</tr>
-
-			<tr valign="top">
-				<th scope="row">
-					<?php esc_html_e( 'CDN URL', 'image-cdn' ); ?>
+					<?php esc_html_e( 'Delivery Address', 'image-cdn' ); ?>
 				</th>
 				<td>
 					<fieldset>
@@ -84,7 +69,7 @@
 							<?php
 							printf(
 								// translators: 1: Link to account control panel.
-								esc_html__( 'Enter your ImageEngine (or other Image CDN) Delivery Address. For ImageEngine, this can be found in your %1$s. In most cases, this will be a scheme and a hostname, like', 'image-cdn' ),
+								esc_html__( 'Enter your ImageEngine (or other Image CDN) Delivery Address. For ImageEngine, this can be found in your %1$s. In most cases, this will be like', 'image-cdn' ),
 								'<a href="https://my.scientiamobile.com/" target="_blank">account control panel</a>'
 							);
 							?>
@@ -93,104 +78,127 @@
 					</fieldset>
 				</td>
 			</tr>
-
 			<tr valign="top">
 				<th scope="row">
-					<?php esc_html_e( 'Included Directories', 'image-cdn' ); ?>
+					<?php esc_html_e( 'Enabled', 'image-cdn' ); ?>
 				</th>
 				<td>
 					<fieldset>
-						<label for="image_cdn_dirs">
-							<input type="text" name="image_cdn[dirs]" id="image_cdn_dirs" value="<?php echo esc_attr( $options['dirs'] ); ?>" size="64" class="regular-text code" />
-							<?php esc_html_e( 'Default:', 'image-cdn' ); ?> <code><?php echo esc_html( $defaults['dirs'] ); ?></code>
-						</label>
-
-						<p class="description">
-							<?php esc_html_e( 'Assets in these directories will be served by the CDN. Enter the directories separated by', 'image-cdn' ); ?> <code>,</code>
-						</p>
-					</fieldset>
-				</td>
-			</tr>
-
-			<tr valign="top">
-				<th scope="row">
-					<?php esc_html_e( 'Exclusions', 'image-cdn' ); ?>
-				</th>
-				<td>
-					<fieldset>
-						<label for="image_cdn_excludes">
-							<input type="text" name="image_cdn[excludes]" id="image_cdn_excludes" value="<?php echo esc_attr( $options['excludes'] ); ?>" size="64" class="regular-text code" />
-							<?php esc_html_e( 'Default', 'image-cdn' ); ?>: <code>.php</code>
-						</label>
-
-						<p class="description">
-							<?php esc_html_e( 'Enter the exclusions (directories or extensions) separated by', 'image-cdn' ); ?> <code>,</code>
-						</p>
-					</fieldset>
-				</td>
-			</tr>
-
-			<tr valign="top">
-				<th scope="row">
-					<?php esc_html_e( 'Relative Path', 'image-cdn' ); ?>
-				</th>
-				<td>
-					<fieldset>
-						<label for="image_cdn_relative">
-							<input type="checkbox" name="image_cdn[relative]" id="image_cdn_relative" value="1" <?php checked( 1, $options['relative'] ); ?> />
-							<?php esc_html_e( 'Enable CDN for relative paths (default: enabled).', 'image-cdn' ); ?>
+						<label for="image_cdn_enabled">
+							<input type="checkbox" name="image_cdn[enabled]" id="image_cdn_enabled" value="1" <?php checked( 1, $options['enabled'] ); ?> />
+							<?php esc_html_e( 'Enable ImageEngine', 'image-cdn' ); ?>
 						</label>
 					</fieldset>
 				</td>
 			</tr>
-
 			<tr valign="top">
 				<th scope="row">
-					<?php esc_html_e( 'CDN HTTPS Support', 'image-cdn' ); ?>
+					<span id="toggle-advanced" style="cursor: pointer;"><?php esc_html_e( 'Show Advanced Settings ▸', 'image-cdn' ); ?></span>
 				</th>
-				<td>
-					<fieldset>
-						<label for="image_cdn_https">
-							<input type="checkbox" name="image_cdn[https]" id="image_cdn_https" value="1" <?php checked( 1, $options['https'] ); ?> />
-							<?php esc_html_e( 'Enable CDN for HTTPS connections (default: disabled).', 'image-cdn' ); ?>
-						</label>
-					</fieldset>
-				</td>
-			</tr>
-
-			<tr valign="top">
-				<th scope="row">
-					<?php esc_html_e( 'ImageEngine Directives', 'image-cdn' ); ?>
-				</th>
-				<td>
-					<fieldset>
-						<label for="image_cdn_directives">
-							<input type="text" name="image_cdn[directives]" id="image_cdn_directives" value="<?php echo esc_attr( $options['directives'] ); ?>" size="64" class="regular-text code" />
-							<?php esc_html_e( 'Optional', 'image-cdn' ); ?>
-						</label>
-
-						<p class="description">
-							<?php
-							echo wp_kses(
-								sprintf(
-									// translators: %s URL to ImageEngine directives.
-									__(
-										'Enter the <a href="%s" target="_blank">ImageEngine Directives</a> to apply to all images.',
-										'image-cdn'
-									),
-									esc_url( 'https://imageengine.io/docs/implementation/directives/?utm_source=WP-plugin-settigns&utm_medium=page&utm_term=wp-imageengine&utm_campaign=wp-imageengine' )
-								),
-								array( 'a' )
-							);
-							?>
-
-							<?php esc_html_e( 'Example', 'image-cdn' ); ?>: <code>/cmpr_10/s_0</code> (<?php esc_html_e( 'sets the compression to 10% and disables sharpening', 'image-cdn' ); ?>)
-						</p>
-					</fieldset>
-				</td>
+				<td></td>
 			</tr>
 		</table>
 
+		<div id="ie-advanced" style="max-height: 0; overflow: hidden; transition: 0.2s ease-in-out;">
+			<p>Please contact us at <a href="mailto:support@imageengine.io?subject=Assitance required with <?php echo esc_attr( $options['url'] ); ?>">support@imageengine.io</a> for help with these settings.</p>
+			<table class="form-table">
+				<tr valign="top">
+					<th scope="row">
+						<?php esc_html_e( 'Included Directories', 'image-cdn' ); ?>
+					</th>
+					<td>
+						<fieldset>
+							<label for="image_cdn_dirs">
+								<input type="text" name="image_cdn[dirs]" id="image_cdn_dirs" value="<?php echo esc_attr( $options['dirs'] ); ?>" size="64" class="regular-text code" />
+								<?php esc_html_e( 'Default:', 'image-cdn' ); ?> <code><?php echo esc_html( $defaults['dirs'] ); ?></code>
+							</label>
+
+							<p class="description">
+								<?php esc_html_e( 'Assets in these directories will be served by the CDN. Enter the directories separated by', 'image-cdn' ); ?> <code>,</code>
+							</p>
+						</fieldset>
+					</td>
+				</tr>
+
+				<tr valign="top">
+					<th scope="row">
+						<?php esc_html_e( 'Exclusions', 'image-cdn' ); ?>
+					</th>
+					<td>
+						<fieldset>
+							<label for="image_cdn_excludes">
+								<input type="text" name="image_cdn[excludes]" id="image_cdn_excludes" value="<?php echo esc_attr( $options['excludes'] ); ?>" size="64" class="regular-text code" />
+								<?php esc_html_e( 'Default', 'image-cdn' ); ?>: <code>.php</code>
+							</label>
+
+							<p class="description">
+								<?php esc_html_e( 'Enter the exclusions (directories or extensions) separated by', 'image-cdn' ); ?> <code>,</code>
+							</p>
+						</fieldset>
+					</td>
+				</tr>
+
+				<tr valign="top">
+					<th scope="row">
+						<?php esc_html_e( 'Relative Path', 'image-cdn' ); ?>
+					</th>
+					<td>
+						<fieldset>
+							<label for="image_cdn_relative">
+								<input type="checkbox" name="image_cdn[relative]" id="image_cdn_relative" value="1" <?php checked( 1, $options['relative'] ); ?> />
+								<?php esc_html_e( 'Enable CDN for relative paths (default: enabled).', 'image-cdn' ); ?>
+							</label>
+						</fieldset>
+					</td>
+				</tr>
+
+				<tr valign="top">
+					<th scope="row">
+						<?php esc_html_e( 'HTTPS Support', 'image-cdn' ); ?>
+					</th>
+					<td>
+						<fieldset>
+							<label for="image_cdn_https">
+								<input type="checkbox" name="image_cdn[https]" id="image_cdn_https" value="1" <?php checked( 1, $options['https'] ); ?> />
+								<?php esc_html_e( 'Enable CDN for HTTPS connections (default: enabled).', 'image-cdn' ); ?>
+							</label>
+						</fieldset>
+					</td>
+				</tr>
+
+				<tr valign="top">
+					<th scope="row">
+						<?php esc_html_e( 'ImageEngine Directives', 'image-cdn' ); ?>
+					</th>
+					<td>
+						<fieldset>
+							<label for="image_cdn_directives">
+								<input type="text" name="image_cdn[directives]" id="image_cdn_directives" value="<?php echo esc_attr( $options['directives'] ); ?>" size="64" class="regular-text code" />
+								<?php esc_html_e( 'Optional', 'image-cdn' ); ?>
+							</label>
+
+							<p class="description">
+								<?php
+								echo wp_kses(
+									sprintf(
+										// translators: %s URL to ImageEngine directives.
+										__(
+											'Enter the <a href="%s" target="_blank">ImageEngine Directives</a> to apply to all images.',
+											'image-cdn'
+										),
+										esc_url( 'https://imageengine.io/docs/implementation/directives/?utm_source=WP-plugin-settigns&utm_medium=page&utm_term=wp-imageengine&utm_campaign=wp-imageengine' )
+									),
+									array( 'a' )
+								);
+								?>
+
+								<?php esc_html_e( 'Example', 'image-cdn' ); ?>: <code>/cmpr_10/s_0</code> (<?php esc_html_e( 'sets the compression to 10% and disables sharpening', 'image-cdn' ); ?>)
+							</p>
+						</fieldset>
+					</td>
+				</tr>
+			</table>
+		</div>
 		<p class="submit">
 			<input type="submit" name="submit" id="submit" class="button button-primary" value="Save Changes">
 			<input type="button" name="check-cdn" id="check-cdn" class="button button-secondary" value="Test Configuration">
@@ -231,3 +239,17 @@
 		<?php esc_html_e( 'CDN Test URL', 'image-cdn' ); ?>: <code class="image-cdn-remote-url"></code>
 	</p>
 </div>
+<script>
+	document.getElementById('toggle-advanced').addEventListener("click", function() {
+		  var panel = document.getElementById('ie-advanced');
+		if (panel.style.maxHeight !='0px') {
+			panel.style.maxHeight = '0px';
+			this.innerHTML=" <?php esc_html_e( 'Show advanced settings ▸', 'image-cdn' ); ?>";
+		} else {
+			panel.style.maxHeight = panel.scrollHeight + "px";
+			this.innerHTML=" <?php esc_html_e( 'Hide advanced settings ▾', 'image-cdn' ); ?>";
+		}
+
+	});
+
+</script>


### PR DESCRIPTION
This PR simplifies the WordPress subdirectory management.

If WP is installed in a subdirectory like `blog`, a user would previously need to enter that dir in the `WordPress Installation Path` setting.  This was confusing and did not work correctly.  This PR removes this setting completely as it is irrelevant.  The `Included Directories` setting already captures the subdir correctly, and this is where it will be managed.

This PR does not break backwards compatibility because the path function wasn't working anyway, and the directories were already detected properly with their subdirs in previous versions.